### PR TITLE
Updated python version requirements

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -554,8 +554,8 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.7, <=3.10"
-content-hash = "09d00606de16760d639db8f0a6f744ec95b46594db47519e5b35a7d29bac22b2"
+python-versions = ">=3.7, <3.11"
+content-hash = "249d6c1f22ce7a1fa96fd4fdcdfa7b35b0db24d6cc1dfd64acbbe86fb028d915"
 
 [metadata.files]
 arrow = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "CLI Utility to upload a clipboard image to a B2 bucket"
 authors = ["ionite34 <dev@ionite.io>"]
 
 [tool.poetry.dependencies]
-python = ">=3.7, <=3.10"
+python = ">=3.7, <3.11"
 Pillow = "^9.1.1"
 keyring = "^23.6.0"
 inquirerpy = "^0.3.4"


### PR DESCRIPTION
Changed python requirement in order to support all 3.10 versions
```
python = ">=3.7, <3.11"
```